### PR TITLE
Set the correct default value for tar_roles.

### DIFF
--- a/lib/capistrano/tasks/copy.rake
+++ b/lib/capistrano/tasks/copy.rake
@@ -7,7 +7,7 @@ namespace :copy do
   exclude_args = exclude_dir.map { |dir| "--exclude '#{dir}'"}
 
   # Defalut to :all roles
-  tar_roles = fetch(:tar_roles, 'all')
+  tar_roles = fetch(:tar_roles, :all)
 
   desc "Archive files to #{archive_name}"
   file archive_name => FileList[include_dir].exclude(archive_name) do |t|


### PR DESCRIPTION
* Fixes #13 capistrano-scm-copy didn't work until I defined tar_roles in my deploy.rb

There are no tests in place, so I skipped that.  OK to merge?