### PR TITLE
Fixing the error "No such file or directory - archive.tar.gz" 

### DIFF
--- a/lib/capistrano/tasks/copy.rake
+++ b/lib/capistrano/tasks/copy.rake
@@ -32,14 +32,14 @@ namespace :copy do
       execute :tar, "-xzf", tmp_file, "-C", release_path
       execute :rm, tmp_file
     end
-
-    Rake::Task["copy:clean"].invoke
   end
 
   task :clean do |t|
     # Delete the local archive
     File.delete archive_name if File.exists? archive_name
   end
+
+  after 'deploy:finished', 'copy:clean'
 
   task :create_release => :deploy
   task :check


### PR DESCRIPTION
Removing rake task call, because it's causing this weird error: "No such file or directory - archive.tar.gz" Adding the correct call using "after" to remove the temp file.
It'll fix this error https://github.com/wercker/capistrano-scm-copy/issues/17 @hatchan