### PR TITLE
Fix issue: exclude_dir doesn't work properly

### DIFF
--- a/lib/capistrano/tasks/copy.rake
+++ b/lib/capistrano/tasks/copy.rake
@@ -2,9 +2,6 @@ namespace :copy do
 
   archive_name = "archive.tar.gz"
   include_dir  = fetch(:include_dir) || "*"
-  exclude_dir  = Array(fetch(:exclude_dir))
-
-  exclude_args = exclude_dir.map { |dir| "--exclude '#{dir}'"}
 
   # Defalut to :all roles
   tar_roles = fetch(:tar_roles, :all)
@@ -13,6 +10,8 @@ namespace :copy do
 
   desc "Archive files to #{archive_name}"
   file archive_name => FileList[include_dir].exclude(archive_name) do |t|
+    exclude_dir  = Array(fetch(:exclude_dir))
+    exclude_args = exclude_dir.map { |dir| "--exclude '#{dir}'"}
     cmd = ["tar -c#{tar_verbose}zf #{t.name}", *exclude_args, *t.prerequisites]
     sh cmd.join(' ')
   end


### PR DESCRIPTION
I'm using Cap 3.4, `exclude_dir` can not be accessed from within the block.
However `fetch` works, so I just moved things into the `file` block and worked perfectly.
Cheers.