### PR TITLE
Uses git repo file list when deploying a repo

### DIFF
--- a/lib/capistrano/tasks/copy.rake
+++ b/lib/capistrano/tasks/copy.rake
@@ -11,8 +11,15 @@ namespace :copy do
 
   tar_verbose = fetch(:tar_verbose, true) ? "v" : ""
 
+  is_git_repo = File.exist?(".git")
   desc "Archive files to #{archive_name}"
-  file archive_name => FileList[include_dir].exclude(archive_name) do |t|
+  if is_git_repo
+    file_list =  FileList.new(`git ls-files --exclude-standard`.split("\n"))
+  else
+    file_list = FileList[include_dir]
+  end
+
+  file archive_name => file_list.exclude(archive_name) do |t|
     cmd = ["tar -c#{tar_verbose}zf #{t.name}", *exclude_args, *t.prerequisites]
     sh cmd.join(' ')
   end


### PR DESCRIPTION
This gem is always vulnerable to accidental copying of files in the project root that are not part of the project.  Temp files, etc.   Rather than depending on the exclude_dir directive, my patch uses git ls-files whenever it detects that the current folder is a git repo.